### PR TITLE
Fix coherent presets with heating and cooling state

### DIFF
--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -1058,9 +1058,11 @@ class Smile:
         directives = self._domain_objects.findall("rule/directives/when/then")
         for directive in directives:
             if directive is not None and "icon" in directive.keys():
-                preset_dictionary[directive.attrib["icon"]] = float(
-                    directive.attrib["temperature"]
-                )
+                # Ensure list of heating_setpoint, cooling_setpoint
+                preset_dictionary[directive.attrib["icon"]] = [
+                    float(directive.attrib["temperature"]),
+                    0,
+                ]
         return preset_dictionary
 
     async def set_preset_legacy(self, preset):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 setup(
     name="Plugwise_Smile",
-    version="0.1.11",
+    version="0.1.12",
     description="Plugwise_Smile (Anna/Adam/P1) API to use in conjunction with Home Assistant.",
     long_description="Plugwise Smile API to use in conjunction with Home Assistant, but it can also be used without Home Assistant as a module.",
     keywords="HomeAssistant HA Home Assistant Anna Adam P1 Smile Plugwise",


### PR DESCRIPTION
Legacy presets werent list [heating_setpoint, cooling_setpoint]. Not sure if anna v1 supports cooling, but the component expects consistency