### PR TITLE
Remove useless water_pressure sensor

### DIFF
--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -707,6 +707,8 @@ class Smile:
                             continue
 
                     measure = appliance.find(pl_value).text
+                    if name == "water_pressure" and float(data[name]) > 3.5:
+                        continue
                     data[name] = self._format_measure(measure)
 
                 il_value = i_locator.format(measurement)

--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -707,7 +707,7 @@ class Smile:
                             continue
 
                     measure = appliance.find(pl_value).text
-                    if name == "water_pressure" and float(data[name]) > 3.5:
+                    if name == "water_pressure" and float(measure) > 3.5:
                         continue
                     data[name] = self._format_measure(measure)
 

--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -707,6 +707,8 @@ class Smile:
                             continue
 
                     measure = appliance.find(pl_value).text
+                    # In some systems there is a pressure-measurement with an unrealistic value,
+                    # this measurement appears a power-on and is never updated, therefore remove. 
                     if name == "water_pressure" and float(measure) > 3.5:
                         continue
                     data[name] = self._format_measure(measure)

--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -708,7 +708,7 @@ class Smile:
 
                     measure = appliance.find(pl_value).text
                     # In some systems there is a pressure-measurement with an unrealistic value,
-                    # this measurement appears a power-on and is never updated, therefore remove. 
+                    # this measurement appears at power-on and is never updated, therefore remove. 
                     if name == "water_pressure" and float(measure) > 3.5:
                         continue
                     data[name] = self._format_measure(measure)

--- a/tests/test_Smile.py
+++ b/tests/test_Smile.py
@@ -743,7 +743,6 @@ class TestPlugwise:
             # Central
             "2743216f626f43948deec1f7ab3b3d70": {
                 "heating_state": False,
-                "water_pressure": 6.0,
             },
             "b128b4bbbd1f47e9bf4d756e8fb5ee94": {"outdoor_temperature": 11.9,},
             # Plug MediaCenter


### PR DESCRIPTION
In my system there is a water_pressure sensor with the value of 6.0
It never updates, must be a bug only seen in the Adam + Anna config.