### PR TITLE
Change to using intended_central_heating_state

### DIFF
--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -715,21 +715,18 @@ class Smile:
                 pl_value = p_locator.format(measurement)
                 if appliance.find(pl_value) is not None:
                     if self._smile_legacy:
-                        if (
-                            measurement == "domestic_hot_water_state" 
-                            or measurement == "central_heating_state"
-                        ):
+                        if measurement == "domestic_hot_water_state":
                             continue
 
                     measure = appliance.find(pl_value).text
                     # In some systems there is a pressure-measurement with an unrealistic value,
                     # this measurement appears at power-on and is never updated, therefore remove. 
-                    if name == "water_pressure" and float(measure) > 3.5:
+                    if measurement == "central_heater_water_pressure" and float(measure) > 3.5:
                         continue
 
                     data[name] = self._format_measure(measure)
 
-                elif name == "heating_state":
+                elif measurement == "intended_central_heating_state":
                     data[name] = None
 
                 il_value = i_locator.format(measurement)

--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -40,28 +40,40 @@ HOME_MEASUREMENTS = {
 # zone_thermosstat 'temperature_offset'
 # radiator_valve 'uncorrected_temperature', 'temperature_offset'
 DEVICE_MEASUREMENTS = {
-    "thermostat": "setpoint",  # HA setpoint
-    "temperature": "temperature",  # HA current_temperature
-    "schedule_temperature": "schedule_temperature",  # only present on legacy_anna and anna_v3
+    # HA setpoint
+    "thermostat": "setpoint",
+    # HA current_temperature
+    "temperature": "temperature",
+    # only present on legacy Anna and Anna_v3
+    "schedule_temperature": "schedule_temperature",
+    #  Lisa and Tom
     "battery": "battery",
     "valve_position": "valve_position",
     "temperature_difference": "temperature_difference",
+    #  Plug
     "electricity_consumed": "electricity_consumed",
     "electricity_produced": "electricity_produced",
     "relay": "relay",
+    #  Outdoor temp as reported on the Anna, in the App
     "outdoor_temperature": "outdoor_temperature",
+    # Anna/Adam: use intended_c_h_state, this key shows the heating-behavior better than c-h_state
+    "intended_central_heating_state": "heating_state",
     "domestic_hot_water_state": "dhw_state",
     "boiler_temperature": "water_temperature",
-    "intended_boiler_temperature": "intended_boiler_temperature",  # use for legacy_anna to detect heating/dhw?
-    "modulation_level": "modulation_level",  # use for legacy_anna to detect heating/dhw?
-    "central_heating_state": "heating_state",
-    "central_heater_water_pressure": "water_pressure",
-    "cooling_state": "cooling_state",  # marcelveldt
-    "boiler_state": "boiler_state",  # a legacy Anna user has this as heating-is-on indication - similar to flame-state on Anna/Adam
-    "intended_boiler_state": "intended_boiler_state",  # WilbertVerhoeff - better indication that heating or dhw is active
-    "slave_boiler_state": "slave_boiler_state",  # marcelveldt
-    "compressor_state": "compressor_state",  # marcelveldt
-    "flame_state": "flame_state",  # added to reliably detect a gas-type local heater device
+    "central_heater_water_pressure": "water_pressure",  # not present on Adam
+    # Legacy Anna only: similar to flame-state on Anna/Adam
+    "boiler_state": "boiler_state",
+    # Legacy Anna ony: shows when heating and/or dhw is active
+    "intended_boiler_state": "intended_boiler_state",
+    # Legacy Anna: use the next two keys to detect heating/dhw?
+    "intended_boiler_temperature": "intended_boiler_temperature",  # non-zero when heating
+    "modulation_level": "modulation_level",  # TBD
+    #  Used with the Elga heatpump - marcelveldt
+    "cooling_state": "cooling_state",
+    # Next  3 keys are used to show the state of the heater used next to the Elga heatpump - marcelveldt
+    "slave_boiler_state": "slave_boiler_state",  
+    "compressor_state": "compressor_state",
+    "flame_state": "flame_state",
 }
 
 SMILES = {

--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -44,31 +44,31 @@ DEVICE_MEASUREMENTS = {
     "thermostat": "setpoint",
     # HA current_temperature
     "temperature": "temperature",
-    # only present on legacy Anna and Anna_v3
+    # Only present on legacy Anna and Anna_v3
     "schedule_temperature": "schedule_temperature",
-    #  Lisa and Tom
+    # Lisa and Tom
     "battery": "battery",
     "valve_position": "valve_position",
     "temperature_difference": "temperature_difference",
-    #  Plug
+    # Plug
     "electricity_consumed": "electricity_consumed",
     "electricity_produced": "electricity_produced",
     "relay": "relay",
-    #  Outdoor temp as reported on the Anna, in the App
+    # Outdoor temp as reported on the Anna, in the App
     "outdoor_temperature": "outdoor_temperature",
     # Anna/Adam: use intended_c_h_state, this key shows the heating-behavior better than c-h_state
     "intended_central_heating_state": "heating_state",
     "domestic_hot_water_state": "dhw_state",
     "boiler_temperature": "water_temperature",
     "central_heater_water_pressure": "water_pressure",  # not present on Adam
-    # Legacy Anna only: similar to flame-state on Anna/Adam
+    # Legacy Anna: similar to flame-state on Anna/Adam
     "boiler_state": "boiler_state",
-    # Legacy Anna ony: shows when heating and/or dhw is active
+    # Legacy Anna: shows when heating and/or dhw is active
     "intended_boiler_state": "intended_boiler_state",
     # Legacy Anna: use the next two keys to detect heating/dhw?
     "intended_boiler_temperature": "intended_boiler_temperature",  # non-zero when heating
     "modulation_level": "modulation_level",  # TBD
-    #  Used with the Elga heatpump - marcelveldt
+    # Used with the Elga heatpump - marcelveldt
     "cooling_state": "cooling_state",
     # Next  3 keys are used to show the state of the heater used next to the Elga heatpump - marcelveldt
     "slave_boiler_state": "slave_boiler_state",  

--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -726,7 +726,11 @@ class Smile:
                     # this measurement appears at power-on and is never updated, therefore remove. 
                     if name == "water_pressure" and float(measure) > 3.5:
                         continue
+
                     data[name] = self._format_measure(measure)
+
+                if name == "heating_state":
+                    data[name] = None
 
                 il_value = i_locator.format(measurement)
                 if appliance.find(il_value) is not None:

--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -729,7 +729,7 @@ class Smile:
 
                     data[name] = self._format_measure(measure)
 
-                if name == "heating_state":
+                elif name == "heating_state":
                     data[name] = None
 
                 il_value = i_locator.format(measurement)

--- a/Plugwise_Smile/__init__.py
+++ b/Plugwise_Smile/__init__.py
@@ -1,5 +1,5 @@
 """Plugwise Smile module."""
 
-__version__ = "0.2.8"
+__version__ = "0.2.9"
 
 from Plugwise_Smile import Smile

--- a/tests/test_Smile.py
+++ b/tests/test_Smile.py
@@ -813,7 +813,7 @@ class TestPlugwise:
                 "battery": 0.67,
             },
             # Adam
-            "90986d591dcd426cae3ec3e8111ff730": {"heating_state": True,},
+            "90986d591dcd426cae3ec3e8111ff730": {"heating_state": None,},
             "fe799307f1624099878210aa0b9f1475": {"outdoor_temperature": 7.7,},
             # Modem
             "675416a629f343c495449970e2ca37b5": {

--- a/tests/test_Smile.py
+++ b/tests/test_Smile.py
@@ -889,7 +889,7 @@ class TestPlugwise:
                 "battery": 0.67,
             },
             # Adam
-            "90986d591dcd426cae3ec3e8111ff730": {"heating_state": True,},
+            "90986d591dcd426cae3ec3e8111ff730": {"heating_state": None,},
             "fe799307f1624099878210aa0b9f1475": {"outdoor_temperature": 7.8,},
             # Modem
             "675416a629f343c495449970e2ca37b5": {


### PR DESCRIPTION
Decided to use this key instead of central_heating_state, as the intended_c_h_state shows the actual heating behavior better, also suggested by @fsaris.
While I'm doing this, I'm seeing that this key has no measurement for some of the Adams with city-heating, directly indicating there is no local heater!