### PR TITLE
Read p1 status

### DIFF
--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -151,7 +151,11 @@ class Smile:
         """Connect to Plugwise device."""
         #pylint: disable=too-many-return-statements
         result = await self.request(DOMAIN_OBJECTS)
-        if "Plugwise" not in result.findall("vendor_name"):
+        names = []
+        vendor_names = result.findall(".//module/vendor_name")
+        for name in vendor_names:
+            names.append(name.text)
+        if "Plugwise" not in names:
             dsmrmain = result.find(".//module/protocols/dsmrmain")
             master_controller = result.find(".//module/protocols/master_controller")
             if dsmrmain is None:

--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -264,6 +264,8 @@ class Smile:
                     resp = await self.websession.put(
                         url, data=data, headers=headers, auth=self._auth
                     )
+            if resp.status == 401:
+                raise self.InvalidAuthentication
 
         except asyncio.TimeoutError:
             if retry < 1:

--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -203,8 +203,8 @@ class Smile:
                     raise self.ConnectionFailedError
     
         if not self._smile_legacy:
-            smile_model = do_xml.find(".//gateway/vendor_model").text
-            smile_version = do_xml.find(".//gateway/firmware_version").text
+            smile_model = result.find(".//gateway/vendor_model").text
+            smile_version = result.find(".//gateway/firmware_version").text
 
         if smile_model is None or smile_version is None:
             _LOGGER.error("Unable to find model or version information")

--- a/Plugwise_Smile/__init__.py
+++ b/Plugwise_Smile/__init__.py
@@ -1,5 +1,5 @@
 """Plugwise Smile module."""
 
-__version__ = "1.3.0a3"
+__version__ = "1.3.0b0"
 
 from Plugwise_Smile import Smile

--- a/tests/smile_p1_v2/system_status_xml.xml
+++ b/tests/smile_p1_v2/system_status_xml.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<system>
 <status>
+<system>
 <product>smile</product>
 <mode>p1</mode>
 <version>2.5.9</version>

--- a/tests/smile_p1_v2/system_status_xml.xml
+++ b/tests/smile_p1_v2/system_status_xml.xml
@@ -1,7 +1,6 @@
-
-<!-- saved from url=(0037)http://127.0.0.1/system/status/xml -->
-<html><head><meta http-equiv="Content-Type" content="text/html; charset=windows-1252"></head><body><status>
+<?xml version="1.0" encoding="ISO-8859-1"?>
 <system>
+<status>
 <product>smile</product>
 <mode>p1</mode>
 <version>2.5.9</version>
@@ -22,4 +21,4 @@
 <mac_address>0123456789AB</mac_address>
 </network>
 </status>
-</body></html>
+

--- a/tests/smile_p1_v2_2/system_status_xml.xml
+++ b/tests/smile_p1_v2_2/system_status_xml.xml
@@ -1,6 +1,5 @@
-
-<!-- saved from url=(0037)http://127.0.0.1/system/status/xml -->
-<html><head><meta http-equiv="Content-Type" content="text/html; charset=windows-1252"></head><body><status>
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<status>
 <system>
 <product>smile</product>
 <mode>p1</mode>
@@ -22,4 +21,3 @@
 <mac_address>0123456789AB</mac_address>
 </network>
 </status>
-</body></html>

--- a/tests/test_Smile.py
+++ b/tests/test_Smile.py
@@ -528,7 +528,7 @@ class TestPlugwise:
 
         self.smile_setup = "smile_p1_v2"
         server, smile, client = await self.connect_wrapper()
-        assert smile.smile_hostname is "smile000000"
+        assert smile.smile_hostname == "smile000000"
 
         _LOGGER.info("Basics:")
         _LOGGER.info(" # Assert type = power")
@@ -564,7 +564,7 @@ class TestPlugwise:
 
         self.smile_setup = "smile_p1_v2_2"
         server, smile, client = await self.connect_wrapper()
-        assert smile.smile_hostname is "smile000000"
+        assert smile.smile_hostname == "smile000000"
 
         _LOGGER.info("Basics:")
         _LOGGER.info(" # Assert type = power")

--- a/tests/test_Smile.py
+++ b/tests/test_Smile.py
@@ -50,6 +50,7 @@ class TestPlugwise:
         app.router.add_get("/core/direct_objects", self.smile_direct_objects)
         app.router.add_get("/core/domain_objects", self.smile_domain_objects)
         app.router.add_get("/core/modules", self.smile_modules)
+        app.router.add_get("/system/status.xml", self.smile_status)
 
         if broken:
             app.router.add_get("/core/locations", self.smile_broken)
@@ -107,6 +108,13 @@ class TestPlugwise:
     async def smile_modules(self, request):
         """Render setup specific modules endpoint."""
         f = open("tests/{}/core.modules.xml".format(self.smile_setup), "r")
+        data = f.read()
+        f.close()
+        return aiohttp.web.Response(text=data)
+
+    async def smile_status(self, request):
+        """Render setup specific status endpoint."""
+        f = open("tests/{}/system_status_xml.xml".format(self.smile_setup), "r")
         data = f.read()
         f.close()
         return aiohttp.web.Response(text=data)

--- a/tests/test_Smile.py
+++ b/tests/test_Smile.py
@@ -528,7 +528,7 @@ class TestPlugwise:
 
         self.smile_setup = "smile_p1_v2"
         server, smile, client = await self.connect_wrapper()
-        assert smile.smile_hostname is None
+        assert smile.smile_hostname is "smile000000"
 
         _LOGGER.info("Basics:")
         _LOGGER.info(" # Assert type = power")
@@ -564,7 +564,7 @@ class TestPlugwise:
 
         self.smile_setup = "smile_p1_v2_2"
         server, smile, client = await self.connect_wrapper()
-        assert smile.smile_hostname is None
+        assert smile.smile_hostname is "smile000000"
 
         _LOGGER.info("Basics:")
         _LOGGER.info(" # Assert type = power")


### PR DESCRIPTION
Changes:
- add support for the P1 with firmware v2.1(.17)
- read xml-data from /system/status.xml (should work for P1 with firmware v2.5)
- for P1 provide hostname for use in plugwise-beta config_flow
- improve/shorten code
- update tests and testdata for above changes (only fixing stuff, no coverage increase)