### PR TITLE
Remove direct objects

### DIFF
--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -130,7 +130,6 @@ class Smile:
         self._timeout = timeout
         self._endpoint = f"http://{host}:{str(port)}"
         self._appliances = None
-        ### self._direct_objects = None ### REMOVE
         self._domain_objects = None
         self._home_location = None
         self._locations = None

--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -851,7 +851,7 @@ class Smile:
                     direct_data[key_string] = val
 
         if direct_data != {}:
-              return direct_data
+            return direct_data
 
     def get_preset(self, loc_id):
         """

--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -125,6 +125,7 @@ class Smile:
             self.websession = websession
 
         self._auth = aiohttp.BasicAuth(username, password=password)
+        ### Work-around for Stretchv2-aiohttp-deflate-error, can be removed for aiohttp v3.7:
         self._headers={'Accept-Encoding': 'gzip'}
 
         self._timeout = timeout
@@ -259,6 +260,7 @@ class Smile:
         try:
             with async_timeout.timeout(self._timeout):
                 if method == "get":
+                    ### Work-around, see above, can be removed for aiohttp v3.7:
                     resp = await self.websession.get(url, auth=self._auth, headers=self._headers)
                 if method == "put":
                     resp = await self.websession.put(

--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -34,7 +34,8 @@ HOME_MEASUREMENTS = {
     "electricity_consumed": "power",
     "electricity_produced": "power",
     "gas_consumed": "gas",
-    "outdoor_temperature": "temperature",
+    # Outdoor temp as reported on the Anna, in the App
+    "outdoor_temperature": "temperature"
 }
 
 # Excluded:
@@ -55,8 +56,6 @@ DEVICE_MEASUREMENTS = {
     "electricity_consumed": "electricity_consumed",
     "electricity_produced": "electricity_produced",
     "relay": "relay",
-    # Outdoor temp as reported on the Anna, in the App
-    "outdoor_temperature": "outdoor_temperature",
     # Anna/Adam: use intended_c_h_state, this key shows the heating-behavior better than c-h_state
     "intended_central_heating_state": "heating_state",
     "domestic_hot_water_state": "dhw_state",
@@ -75,7 +74,7 @@ DEVICE_MEASUREMENTS = {
     # Next  3 keys are used to show the state of the heater used next to the Elga heatpump - marcelveldt
     "slave_boiler_state": "slave_boiler_state",
     "compressor_state": "compressor_state",
-    "flame_state": "flame_state",
+    "flame_state": "flame_state"
 }
 
 SMILES = {
@@ -92,8 +91,8 @@ SMILES = {
     "smile_v33": {"type": "power", "friendly_name": "P1",},
     "smile_v25": {"type": "power", "friendly_name": "P1", "legacy": True,},
     "smile_v21": {"type": "power", "friendly_name": "P1", "legacy": True,},
-    "stretch_v23" : {"type": "stretch_v2", "friendly_name": "Stretch", "legacy": True},
-    "stretch_v31" : {"type": "stretch_v3", "friendly_name": "Stretch", "legacy": True}
+    "stretch_v31" : {"type": "stretch_v3", "friendly_name": "Stretch", "legacy": True},
+    "stretch_v23" : {"type": "stretch_v2", "friendly_name": "Stretch", "legacy": True}
 }
 
 
@@ -131,7 +130,7 @@ class Smile:
         self._timeout = timeout
         self._endpoint = f"http://{host}:{str(port)}"
         self._appliances = None
-        self._direct_objects = None
+        ### self._direct_objects = None ### REMOVE
         self._domain_objects = None
         self._home_location = None
         self._locations = None
@@ -314,15 +313,6 @@ class Smile:
         if new_data is not None:
             self._appliances = new_data
 
-    async def update_direct_objects(self):
-        """Request direct_objects data."""
-        if self._smile_legacy and self.smile_type == "power":
-            return True
-
-        new_data = await self.request(DIRECT_OBJECTS)
-        if new_data is not None:
-            self._direct_objects = new_data
-
     async def update_domain_objects(self):
         """Request domain_objects data."""
         new_data = await self.request(DOMAIN_OBJECTS)
@@ -361,14 +351,6 @@ class Smile:
             self.smile_type == "power" and not self._smile_legacy
         ):
             _LOGGER.error("Appliance data missing")
-            raise self.XMLDataMissingError
-
-        await self.update_direct_objects()
-        # P1 legacy has no direct_objects
-        if self._direct_objects is None and (
-            self.smile_type == "power" and not self._smile_legacy
-        ):
-            _LOGGER.error("Direct_objects data missing")
             raise self.XMLDataMissingError
 
         await self.update_domain_objects()
@@ -718,26 +700,21 @@ class Smile:
 
         # Anna specific
         if details["class"] in ["thermostat"]:
-            device_data["illuminance"] = self.get_object_value(
-                "appliance", dev_id, "illuminance"
-            )
+            illuminance = self.get_object_value("appliance", dev_id, "illuminance")
+            if illuminance is not None:
+                device_data["illuminance"] = illuminance
 
         # Generic
         if details["class"] == "gateway" or dev_id == self.gateway_id:
-
             # Try to get P1 data
-            power_data = self.get_direct_objects_from_location(details["location"])
+            power_data = self.get_power_data_from_location(details["location"])
             if power_data is not None:
                 device_data.update(power_data)
 
-            heater_data = self.get_appliance_data(self.heater_id)
-            outdoor_temperature = heater_data.get("outdoor_temperature")
-            if outdoor_temperature is None:
-                outdoor_temperature = self.get_object_value(
-                    "location", self._home_location, "outdoor_temperature"
-                )
-
-            if outdoor_temperature:
+            outdoor_temperature = self.get_object_value(
+                "location", self._home_location, "outdoor_temperature"
+            )
+            if outdoor_temperature is not None:
                 device_data["outdoor_temperature"] = outdoor_temperature
 
         return device_data
@@ -816,18 +793,12 @@ class Smile:
                     measure = False
         return measure
 
-    def get_direct_objects_from_location(self, loc_id):
-        """
-        Obtain the appliance-data from appliances without a location.
-
-        Determined from DIRECT_OBJECTS.
-        """
+    def get_power_data_from_location(self, loc_id):
+        """Obtain the power-data from domain_objects based on location."""
         direct_data = {}
-        search = self._direct_objects
+        search = self._domain_objects
         t_string = "tariff"
-
         if self._smile_legacy and self.smile_type == "power":
-            search = self._domain_objects
             t_string = "tariff_indicator"
 
         loc_logs = search.find(f'.//location[@id="{loc_id}"]/logs')
@@ -881,7 +852,7 @@ class Smile:
                     direct_data[key_string] = val
 
         if direct_data != {}:
-            return direct_data
+              return direct_data
 
     def get_preset(self, loc_id):
         """
@@ -1092,21 +1063,19 @@ class Smile:
         if schema_ids != {}:
             return schema_ids
 
-    def get_object_value(self, obj_type, appl_id, measurement):
-        """Obtain the illuminance value from the thermostat."""
-        search = self._direct_objects
-
-        if self._smile_legacy and self.smile_type == "power":
-            search = self._domain_objects
+    def get_object_value(self, obj_type, obj_id, measurement):
+        """Obtain the object-value from the thermostat."""
+        search = self._domain_objects
 
         locator = (
-            f'.//{obj_type}[@id="{appl_id}"]/logs/point_log'
+            f'.//{obj_type}[@id="{obj_id}"]/logs/point_log'
             f'[type="{measurement}"]/period/measurement'
         )
         if search.find(locator) is not None:
             val = float(f"{round(float(search.find(locator).text), 1):.1f}")
-
             return val
+
+        return None
 
     async def set_schedule_state(self, loc_id, name, state):
         """

--- a/Plugwise_Smile/__init__.py
+++ b/Plugwise_Smile/__init__.py
@@ -1,5 +1,5 @@
 """Plugwise Smile module."""
 
-__version__ = "1.3.0b3"
+__version__ = "1.3.0b4"
 
 from Plugwise_Smile import Smile

--- a/tests/p1v3solarfake/core.domain_objects.xml
+++ b/tests/p1v3solarfake/core.domain_objects.xml
@@ -117,7 +117,7 @@
 				<last_consecutive_log_date>2020-03-12T21:00:00+01:00</last_consecutive_log_date>
 				<period start_date="2020-03-12T21:00:00+01:00" end_date="2020-03-12T21:00:00+01:00">
 					<measurement log_date="2020-03-12T21:00:00+01:00" tariff="nl_peak">20000.00</measurement>
-					<measurement log_date="2020-03-12T21:00:00+01:00" tariff="nl_offpeak">3000.00</measurement>
+					<measurement log_date="2020-03-12T21:00:00+01:00" tariff="nl_offpeak">300.00</measurement>
 				</period>
 				<electricity_cumulative_meter id='1fa5f5772e464e5cbcb595101adaf8e5'/>
 			</cumulative_log>
@@ -127,7 +127,7 @@
 				<unit>W</unit>
 				<last_consecutive_log_date>2020-03-12T16:54:42+01:00</last_consecutive_log_date>
 				<period start_date="2020-03-12T21:14:01+01:00" end_date="2020-03-12T21:14:01+01:00">
-					<measurement log_date="2020-03-12T21:14:01+01:00" tariff="nl_offpeak">2000.00</measurement>
+					<measurement log_date="2020-03-12T21:14:01+01:00" tariff="nl_offpeak">200.00</measurement>
 				</period>
 				<electricity_point_meter id='b0618815236d47a2b093a1a7ba83991d'/>
 			</point_log>

--- a/tests/p1v3solarfake/core.domain_objects.xml
+++ b/tests/p1v3solarfake/core.domain_objects.xml
@@ -105,7 +105,7 @@
 				<unit>W</unit>
 				<last_consecutive_log_date>2020-03-12T21:14:01+01:00</last_consecutive_log_date>
 				<period start_date="2020-03-12T21:14:01+01:00" end_date="2020-03-12T21:14:01+01:00">
-					<measurement log_date="2020-03-12T21:14:01+01:00" tariff="nl_peak">650.00</measurement>
+					<measurement log_date="2020-03-12T21:14:01+01:00" tariff="nl_peak">644.00</measurement>
 					<measurement log_date="2020-03-12T21:14:01+01:00" tariff="nl_offpeak">0.00</measurement>
 				</period>
 				<electricity_point_meter id='b0618815236d47a2b093a1a7ba83991d'/>
@@ -116,8 +116,8 @@
 				<unit>Wh</unit>
 				<last_consecutive_log_date>2020-03-12T21:00:00+01:00</last_consecutive_log_date>
 				<period start_date="2020-03-12T21:00:00+01:00" end_date="2020-03-12T21:00:00+01:00">
-					<measurement log_date="2020-03-12T21:00:00+01:00" tariff="nl_peak">0.00</measurement>
-					<measurement log_date="2020-03-12T21:00:00+01:00" tariff="nl_offpeak">0.00</measurement>
+					<measurement log_date="2020-03-12T21:00:00+01:00" tariff="nl_peak">20000.00</measurement>
+					<measurement log_date="2020-03-12T21:00:00+01:00" tariff="nl_offpeak">3000.00</measurement>
 				</period>
 				<electricity_cumulative_meter id='1fa5f5772e464e5cbcb595101adaf8e5'/>
 			</cumulative_log>
@@ -127,7 +127,7 @@
 				<unit>W</unit>
 				<last_consecutive_log_date>2020-03-12T16:54:42+01:00</last_consecutive_log_date>
 				<period start_date="2020-03-12T21:14:01+01:00" end_date="2020-03-12T21:14:01+01:00">
-					<measurement log_date="2020-03-12T21:14:01+01:00" tariff="nl_offpeak">0.00</measurement>
+					<measurement log_date="2020-03-12T21:14:01+01:00" tariff="nl_offpeak">2000.00</measurement>
 				</period>
 				<electricity_point_meter id='b0618815236d47a2b093a1a7ba83991d'/>
 			</point_log>
@@ -149,8 +149,8 @@
 				<last_consecutive_log_date>2020-03-12T20:45:00+01:00</last_consecutive_log_date>
 				<interval>PT15M</interval>
 				<period start_date="2020-03-12T20:45:00+01:00" end_date="2020-03-12T20:45:00+01:00" interval="PT15M">
-					<measurement log_date="2020-03-12T20:45:00+01:00" tariff="nl_peak">0.00</measurement>
-					<measurement log_date="2020-03-12T20:45:00+01:00" tariff="nl_offpeak">0.00</measurement>
+					<measurement log_date="2020-03-12T20:45:00+01:00" tariff="nl_peak">1000.00</measurement>
+					<measurement log_date="2020-03-12T20:45:00+01:00" tariff="nl_offpeak">20.00</measurement>
 				</period>
 				<electricity_interval_meter id='b3e07d45b7354d189cd0d5d41a4f80d7'/>
 			</interval_log>

--- a/tests/test_Smile.py
+++ b/tests/test_Smile.py
@@ -1048,7 +1048,7 @@ class TestPlugwise:
                 "electricity_consumed_peak_point": 644.0,
                 "electricity_produced_peak_cumulative": 20000.0,
                 "electricity_consumed_off_peak_cumulative": 10263159.0,
-                "net_electricity_point": -3356.0,
+                "net_electricity_point": 244,
             }
         }
 

--- a/tests/test_Smile.py
+++ b/tests/test_Smile.py
@@ -1165,7 +1165,7 @@ class TestPlugwise:
                 "water_temperature": 24.7,
                 "water_pressure": 1.61,
             },
-            "015ae9ea3f964e668e490fa39da3870b": {"outdoor_temperature": 21.0,},
+            "015ae9ea3f964e668e490fa39da3870b": {"outdoor_temperature": 22.0,},
         }
 
         self.smile_setup = "anna_heatpump_cooling"

--- a/tests/test_Smile.py
+++ b/tests/test_Smile.py
@@ -1013,7 +1013,7 @@ class TestPlugwise:
         testdata = {
             # Gateway / P1 itself
             "ba4de7613517478da82dd9b6abea36af": {
-                "electricity_consumed_peak_point": 650.0, #644.0,
+                "electricity_consumed_peak_point": 644.0,
                 "electricity_produced_peak_cumulative": 0.0,
                 "electricity_consumed_off_peak_cumulative": 10263159.0,
             }
@@ -1045,7 +1045,7 @@ class TestPlugwise:
         testdata = {
             # Gateway / P1 itself
             "ba4de7613517478da82dd9b6abea36af": {
-                "electricity_consumed_peak_point": 650, #644.0,
+                "electricity_consumed_peak_point": 644.0,
                 "electricity_produced_peak_cumulative": 20000.0,
                 "electricity_consumed_off_peak_cumulative": 10263159.0,
                 "net_electricity_point": 244.0,

--- a/tests/test_Smile.py
+++ b/tests/test_Smile.py
@@ -1013,7 +1013,7 @@ class TestPlugwise:
         testdata = {
             # Gateway / P1 itself
             "ba4de7613517478da82dd9b6abea36af": {
-                "electricity_consumed_peak_point": 650.0 #644.0,
+                "electricity_consumed_peak_point": 650.0, #644.0,
                 "electricity_produced_peak_cumulative": 0.0,
                 "electricity_consumed_off_peak_cumulative": 10263159.0,
             }
@@ -1045,7 +1045,7 @@ class TestPlugwise:
         testdata = {
             # Gateway / P1 itself
             "ba4de7613517478da82dd9b6abea36af": {
-                "electricity_consumed_peak_point": 650 #644.0,
+                "electricity_consumed_peak_point": 650, #644.0,
                 "electricity_produced_peak_cumulative": 20000.0,
                 "electricity_consumed_off_peak_cumulative": 10263159.0,
                 "net_electricity_point": 244.0,

--- a/tests/test_Smile.py
+++ b/tests/test_Smile.py
@@ -1013,7 +1013,7 @@ class TestPlugwise:
         testdata = {
             # Gateway / P1 itself
             "ba4de7613517478da82dd9b6abea36af": {
-                "electricity_consumed_peak_point": 644.0,
+                "electricity_consumed_peak_point": 650.0,
                 "electricity_produced_peak_cumulative": 0.0,
                 "electricity_consumed_off_peak_cumulative": 10263159.0,
             }
@@ -1048,7 +1048,7 @@ class TestPlugwise:
                 "electricity_consumed_peak_point": 644.0,
                 "electricity_produced_peak_cumulative": 20000.0,
                 "electricity_consumed_off_peak_cumulative": 10263159.0,
-                "net_electricity_point": 244.0,
+                "net_electricity_point": -3356.0,
             }
         }
 
@@ -1156,7 +1156,7 @@ class TestPlugwise:
             # Anna
             "3cb70739631c4d17a86b8b12e8a5161b": {
                 "selected_schedule": None,
-                "illuminance": 25.5,
+                "illuminance": 24.5,
                 "active_preset": "home",
             },
             # Central

--- a/tests/test_Smile.py
+++ b/tests/test_Smile.py
@@ -47,7 +47,7 @@ class TestPlugwise:
         """Create mock webserver for Smile to interface with."""
         app = aiohttp.web.Application()
         app.router.add_get("/core/appliances", self.smile_appliances)
-        app.router.add_get("/core/direct_objects", self.smile_direct_objects)
+        #app.router.add_get("/core/direct_objects", self.smile_direct_objects)
         app.router.add_get("/core/domain_objects", self.smile_domain_objects)
         app.router.add_get("/core/modules", self.smile_modules)
         app.router.add_get("/system/status.xml", self.smile_status)
@@ -84,12 +84,12 @@ class TestPlugwise:
         f.close()
         return aiohttp.web.Response(text=data)
 
-    async def smile_direct_objects(self, request):
-        """Render setup specific direct objects endpoint."""
-        f = open("tests/{}/core.direct_objects.xml".format(self.smile_setup), "r")
-        data = f.read()
-        f.close()
-        return aiohttp.web.Response(text=data)
+    #async def smile_direct_objects(self, request):
+    #    """Render setup specific direct objects endpoint."""
+    #    f = open("tests/{}/core.direct_objects.xml".format(self.smile_setup), "r")
+    #    data = f.read()
+    #    f.close()
+    #    return aiohttp.web.Response(text=data)
 
     async def smile_domain_objects(self, request):
         """Render setup specific domain objects endpoint."""

--- a/tests/test_Smile.py
+++ b/tests/test_Smile.py
@@ -47,7 +47,6 @@ class TestPlugwise:
         """Create mock webserver for Smile to interface with."""
         app = aiohttp.web.Application()
         app.router.add_get("/core/appliances", self.smile_appliances)
-        #app.router.add_get("/core/direct_objects", self.smile_direct_objects)
         app.router.add_get("/core/domain_objects", self.smile_domain_objects)
         app.router.add_get("/core/modules", self.smile_modules)
         app.router.add_get("/system/status.xml", self.smile_status)
@@ -83,13 +82,6 @@ class TestPlugwise:
         data = f.read()
         f.close()
         return aiohttp.web.Response(text=data)
-
-    #async def smile_direct_objects(self, request):
-    #    """Render setup specific direct objects endpoint."""
-    #    f = open("tests/{}/core.direct_objects.xml".format(self.smile_setup), "r")
-    #    data = f.read()
-    #    f.close()
-    #    return aiohttp.web.Response(text=data)
 
     async def smile_domain_objects(self, request):
         """Render setup specific domain objects endpoint."""

--- a/tests/test_Smile.py
+++ b/tests/test_Smile.py
@@ -793,7 +793,6 @@ class TestPlugwise:
             "ee62cad889f94e8ca3d09021f03a660b": {
                 "selected_schedule": "Weekschema",
                 "last_used": "Weekschema",
-                "illuminance": None,
                 "active_preset": "home",
                 "setpoint": 20.5,  # HA setpoint_temp
                 "temperature": 20.5,  # HA current_temp
@@ -1014,7 +1013,7 @@ class TestPlugwise:
         testdata = {
             # Gateway / P1 itself
             "ba4de7613517478da82dd9b6abea36af": {
-                "electricity_consumed_peak_point": 644.0,
+                "electricity_consumed_peak_point": 650.0 #644.0,
                 "electricity_produced_peak_cumulative": 0.0,
                 "electricity_consumed_off_peak_cumulative": 10263159.0,
             }
@@ -1046,7 +1045,7 @@ class TestPlugwise:
         testdata = {
             # Gateway / P1 itself
             "ba4de7613517478da82dd9b6abea36af": {
-                "electricity_consumed_peak_point": 644.0,
+                "electricity_consumed_peak_point": 650 #644.0,
                 "electricity_produced_peak_cumulative": 20000.0,
                 "electricity_consumed_off_peak_cumulative": 10263159.0,
                 "net_electricity_point": 244.0,

--- a/tests/test_Smile.py
+++ b/tests/test_Smile.py
@@ -1082,8 +1082,8 @@ class TestPlugwise:
                 "electricity_consumed_peak_point": 0.0,
                 "electricity_produced_peak_cumulative": 396559.0,
                 "electricity_consumed_off_peak_cumulative": 551090.0,
-                "electricity_produced_peak_point": 2809.0,
-                "net_electricity_point": -2809.0,
+                "electricity_produced_peak_point": 2761.0,
+                "net_electricity_point": -2761.0,
                 "gas_consumed_cumulative": 584.9,
             }
         }
@@ -1125,7 +1125,7 @@ class TestPlugwise:
                 "water_temperature": 29.1,
                 "water_pressure": 1.57,
             },
-            "015ae9ea3f964e668e490fa39da3870b": {"outdoor_temperature": 18.0,},
+            "015ae9ea3f964e668e490fa39da3870b": {"outdoor_temperature": 20.2,},
         }
 
         self.smile_setup = "anna_heatpump"


### PR DESCRIPTION
In all relevant (test)cases the data taken from /core/direct_objects is available in /core/domain_objects, so let's not read /core/direct_objects from the Smiles.