### PR TITLE
Revert defaults

### DIFF
--- a/Plugwise_Smile/Smile.py
+++ b/Plugwise_Smile/Smile.py
@@ -27,6 +27,8 @@ SYSTEM = "/system"
 STATUS = "/system/status.xml"
 
 DEFAULT_TIMEOUT = 30
+DEFAULT_USERNAME = "smile"
+DEFAULT_PORT = 80
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -132,8 +134,8 @@ class Smile:
         self,
         host,
         password,
-        username,
-        port,
+        username=DEFAULT_USERNAME,
+        port=DEFAULT_PORT,
         timeout=DEFAULT_TIMEOUT,
         websession: aiohttp.ClientSession = None,
     ):

--- a/Plugwise_Smile/__init__.py
+++ b/Plugwise_Smile/__init__.py
@@ -1,5 +1,5 @@
 """Plugwise Smile module."""
 
-__version__ = "1.3.0b12"
+__version__ = "1.3.0b13"
 
 from Plugwise_Smile import Smile


### PR DESCRIPTION
Bring back username (and port while at it) as defaults to keep testing to defaults while still allowing for Stretches to allow to override (or users with Smiles in DMZs)